### PR TITLE
Feature/tps_protection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Nenne alle neu in dieser PR hinzugefügten Repositories im buildscript, indem du
 <br>
 
 ### Neu hinzugefügte Abhängigkeiten
-Liste hier alle neu in dieser PR hinzugefügten Abhängigkeiten auf. Nutze dafür das Formar _groupid:artifact:version_ <br>
+Liste hier alle neu in dieser PR hinzugefügten Abhängigkeiten auf. Nutze dafür das Format _groupid:artifact:version_ <br>
 - io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT
 - org.jetbrains:annotations:24.1.0
 - com.google.code.gson:gson:2.10.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,13 @@ repositories {
     maven("https://repo.aikar.co/content/groups/aikar/")
     maven("https://repo.minebench.de/")
     maven("https://repo.codemc.io/repository/maven-snapshots/")
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 dependencies {
     // Dependencies that are available at runtime
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+    compileOnly("me.lucko:spark-api:0.1-SNAPSHOT")
 
     // Dependencies that have to be shadowed
     implementation("org.jetbrains:annotations:24.1.0")
@@ -114,4 +116,5 @@ bukkit {
     load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
     author = "ByTRYO"
     contributors = listOf("Merry", "GhostException", "DeRio_")
+    depend = listOf("spark")
 }

--- a/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
+++ b/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
@@ -13,6 +13,8 @@ import net.quantrax.citybuild.backend.dao.impl.repository.PlayerRepository;
 import net.quantrax.citybuild.backend.tracking.PlayerTrackingListener;
 import net.quantrax.citybuild.commands.*;
 import net.quantrax.citybuild.listener.CustomInventoryListener;
+import net.quantrax.citybuild.listener.TPSProtectionListener;
+import net.quantrax.citybuild.utils.TPSProtector;
 import net.quantrax.citybuild.utils.WorldLoader;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
@@ -28,6 +30,8 @@ public class CityBuildPlugin extends JavaPlugin {
     private PlayerCache playerCache;
     private LocationCache locationCache;
     private MessageCache messageCache;
+
+    private TPSProtector tpsProtector;
 
     @Override
     public void onLoad() {
@@ -49,6 +53,9 @@ public class CityBuildPlugin extends JavaPlugin {
         messageCache = MessageCache.getInstance(messageRepository);
         locationCache = LocationCache.getInstance(new LocationRepository());
 
+        tpsProtector = new TPSProtector(this, messageCache);
+        tpsProtector.supervice();
+
         registerListener();
         registerCommands();
     }
@@ -57,6 +64,7 @@ public class CityBuildPlugin extends JavaPlugin {
         PluginManager pluginManager = Bukkit.getPluginManager();
         pluginManager.registerEvents(new PlayerTrackingListener(playerCache, playerRepository), this);
         pluginManager.registerEvents(new CustomInventoryListener(), this);
+        pluginManager.registerEvents(new TPSProtectionListener(tpsProtector), this);
     }
 
     private void registerCommands() {

--- a/src/main/java/net/quantrax/citybuild/listener/TPSProtectionListener.java
+++ b/src/main/java/net/quantrax/citybuild/listener/TPSProtectionListener.java
@@ -1,0 +1,21 @@
+package net.quantrax.citybuild.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.quantrax.citybuild.utils.TPSProtector;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockRedstoneEvent;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class TPSProtectionListener implements Listener {
+
+    private final TPSProtector protector;
+
+    @EventHandler
+    public void onRedstone(@NotNull BlockRedstoneEvent event) {
+        if (!protector.allowRedstone()) {
+            event.setNewCurrent(0);
+        }
+    }
+}

--- a/src/main/java/net/quantrax/citybuild/utils/ComponentTranslator.java
+++ b/src/main/java/net/quantrax/citybuild/utils/ComponentTranslator.java
@@ -15,7 +15,7 @@ public class ComponentTranslator {
         return MiniMessage.miniMessage().deserialize(path, TagResolver.standard());
     }
 
-    public static @NotNull Component fromDatabase(@NotNull MessageCache cache, @NotNull String key) {
+    public static @NotNull Component fromCache(@NotNull MessageCache cache, @NotNull String key) {
         String input = cache.get(key);
         Preconditions.state(input != null, "Could not find %s in database", key);
 
@@ -23,7 +23,7 @@ public class ComponentTranslator {
     }
 
     public static @NotNull Component withReplacements(@NotNull MessageCache cache, @NotNull String key, @NotNull List<Replacement<?>> replacements) {
-        if (replacements.isEmpty()) return fromDatabase(cache, key);
+        if (replacements.isEmpty()) return fromCache(cache, key);
 
         String raw = cache.get(key);
         Preconditions.state(raw != null, "Could not find %s in config.toml", key);

--- a/src/main/java/net/quantrax/citybuild/utils/DiscordWebhook.java
+++ b/src/main/java/net/quantrax/citybuild/utils/DiscordWebhook.java
@@ -1,0 +1,268 @@
+package net.quantrax.citybuild.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.awt.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static net.quantrax.citybuild.utils.DiscordWebhook.EmbedObject.Field;
+
+public class DiscordWebhook {
+
+    private final String url;
+    @Setter private String content;
+    @Setter private String username;
+    @Setter private String avatarUrl;
+    @Setter private boolean tts;
+    private final List<EmbedObject> embeds = new ArrayList<>();
+
+    public DiscordWebhook(String url) {
+        this.url = url;
+    }
+
+    public void addEmbed(EmbedObject embed) {
+        this.embeds.add(embed);
+    }
+
+    public void execute() throws IOException {
+        if (this.content == null && this.embeds.isEmpty()) {
+            throw new IllegalArgumentException("Set content or add at least one EmbedObject");
+        }
+
+        JSONObject json = new JSONObject();
+
+        json.put("content", this.content);
+        json.put("username", this.username);
+        json.put("avatar_url", this.avatarUrl);
+        json.put("tts", this.tts);
+
+        if (!this.embeds.isEmpty()) {
+            List<JSONObject> embedObjects = new ArrayList<>();
+
+            for (EmbedObject embed : this.embeds) {
+                JSONObject jsonEmbed = new JSONObject();
+
+                jsonEmbed.put("title", embed.title());
+                jsonEmbed.put("description", embed.description());
+                jsonEmbed.put("url", embed.url());
+
+                if (embed.color() != null) {
+                    Color color = embed.color();
+                    int rgb = color.getRed();
+                    rgb = (rgb << 8) + color.getGreen();
+                    rgb = (rgb << 8) + color.getBlue();
+
+                    jsonEmbed.put("color", rgb);
+                }
+
+                var footer = embed.footer();
+                var image = embed.image();
+                var thumbnail = embed.thumbnail();
+                var author = embed.author();
+                var fields = embed.fields();
+
+                if (footer != null) {
+                    JSONObject jsonFooter = new JSONObject();
+
+                    jsonFooter.put("text", footer.text());
+                    jsonFooter.put("icon_url", footer.iconUrl());
+                    jsonEmbed.put("footer", jsonFooter);
+                }
+
+                if (image != null) {
+                    JSONObject jsonImage = new JSONObject();
+
+                    jsonImage.put("url", image.url());
+                    jsonEmbed.put("image", jsonImage);
+                }
+
+                if (thumbnail != null) {
+                    JSONObject jsonThumbnail = new JSONObject();
+
+                    jsonThumbnail.put("url", thumbnail.url());
+                    jsonEmbed.put("thumbnail", jsonThumbnail);
+                }
+
+                if (author != null) {
+                    JSONObject jsonAuthor = new JSONObject();
+
+                    jsonAuthor.put("name", author.name());
+                    jsonAuthor.put("url", author.url());
+                    jsonAuthor.put("icon_url", author.iconUrl());
+                    jsonEmbed.put("author", jsonAuthor);
+                }
+
+                List<JSONObject> jsonFields = new ArrayList<>();
+                for (Field field : fields) {
+                    JSONObject jsonField = new JSONObject();
+
+                    jsonField.put("name", field.name());
+                    jsonField.put("value", field.value());
+                    jsonField.put("inline", field.inline());
+
+                    jsonFields.add(jsonField);
+                }
+
+                jsonEmbed.put("fields", jsonFields.toArray());
+                embedObjects.add(jsonEmbed);
+            }
+
+            json.put("embeds", embedObjects.toArray());
+        }
+
+        URL url = new URL(this.url);
+        HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+        connection.addRequestProperty("Content-Type", "application/json");
+        connection.addRequestProperty("User-Agent", "Quantrax-DiscordWebhook");
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+
+        OutputStream stream = connection.getOutputStream();
+        stream.write(json.toString().getBytes());
+        stream.flush();
+        stream.close();
+
+        connection.getInputStream().close();
+        connection.disconnect();
+    }
+
+    @Getter
+    public static class EmbedObject {
+        private String title;
+        private String description;
+        private String url;
+        private Color color;
+
+        private Footer footer;
+        private Thumbnail thumbnail;
+        private Image image;
+        private Author author;
+        private final List<Field> fields = new ArrayList<>();
+
+        public EmbedObject title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public EmbedObject description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public EmbedObject url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public EmbedObject color(Color color) {
+            this.color = color;
+            return this;
+        }
+
+        public EmbedObject footer(String text, String icon) {
+            this.footer = new Footer(text, icon);
+            return this;
+        }
+
+        public EmbedObject thumbnail(String url) {
+            this.thumbnail = new Thumbnail(url);
+            return this;
+        }
+
+        public EmbedObject image(String url) {
+            this.image = new Image(url);
+            return this;
+        }
+
+        public EmbedObject author(String name, String url, String icon) {
+            this.author = new Author(name, url, icon);
+            return this;
+        }
+
+        public EmbedObject addField(String name, String value, boolean inline) {
+            this.fields.add(new Field(name, value, inline));
+            return this;
+        }
+
+        public record Footer(String text, String iconUrl) {
+        }
+
+        public record Thumbnail(String url) {
+        }
+
+        public record Image(String url) {
+        }
+
+        public record Author(String name, String url, String iconUrl) {
+        }
+
+        public record Field(String name, String value, boolean inline) {
+        }
+    }
+
+    private static class JSONObject {
+
+        private final HashMap<String, Object> map = new HashMap<>();
+
+        void put(String key, Object value) {
+            if (value != null) {
+                map.put(key, value);
+            }
+        }
+
+        @Override
+        public @NotNull String toString() {
+            StringBuilder builder = new StringBuilder();
+            Set<Entry<String, Object>> entrySet = map.entrySet();
+            builder.append("{");
+
+            int i = 0;
+            for (Entry<String, Object> entry : entrySet) {
+                Object val = entry.getValue();
+                builder.append(quote(entry.getKey())).append(":");
+
+                if (val instanceof String) {
+                    builder.append(quote(String.valueOf(val)));
+
+                } else if (val instanceof Integer) {
+                    builder.append(Integer.valueOf(String.valueOf(val)));
+
+                } else if (val instanceof Boolean) {
+                    builder.append(val);
+
+                } else if (val instanceof JSONObject) {
+                    builder.append(val);
+
+                } else if (val.getClass().isArray()) {
+                    builder.append("[");
+                    int len = Array.getLength(val);
+                    for (int j = 0; j < len; j++) {
+                        builder.append(Array.get(val, j).toString()).append(j != len - 1 ? "," : "");
+                    }
+                    builder.append("]");
+                }
+
+                builder.append(++i == entrySet.size() ? "}" : ",");
+            }
+
+            return builder.toString();
+        }
+
+        @Contract(pure = true)
+        private @NotNull String quote(String string) {
+            return "\"" + string + "\"";
+        }
+    }
+}

--- a/src/main/java/net/quantrax/citybuild/utils/Log.java
+++ b/src/main/java/net/quantrax/citybuild/utils/Log.java
@@ -20,4 +20,9 @@ public final class Log {
     public static void info(@FormatString @NotNull String template, Object... args) {
         LOGGER.info(String.format(template, args));
     }
+
+    @FormatMethod
+    public static void warn(@FormatString @NotNull String template, Object... args) {
+        LOGGER.warning(String.format(template, args));
+    }
 }

--- a/src/main/java/net/quantrax/citybuild/utils/TPSProtector.java
+++ b/src/main/java/net/quantrax/citybuild/utils/TPSProtector.java
@@ -1,0 +1,154 @@
+package net.quantrax.citybuild.utils;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import me.lucko.spark.api.Spark;
+import me.lucko.spark.api.statistic.StatisticWindow;
+import me.lucko.spark.api.statistic.types.DoubleStatistic;
+import net.kyori.adventure.text.Component;
+import net.quantrax.citybuild.CityBuildPlugin;
+import net.quantrax.citybuild.backend.cache.MessageCache;
+import net.quantrax.citybuild.utils.DiscordWebhook.EmbedObject;
+import net.quantrax.citybuild.utils.Messenger.Replacement;
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+public class TPSProtector {
+
+    public static final double LIMIT_SHUTDOWN = 7.1D, LIMIT_ALLOW_REDSTONE = 10.1D, LIMIT_WARN = 15.1D;
+
+    private final ScheduledExecutorService threadPool = new ScheduledThreadPoolExecutor(3);
+    @Getter @Setter private boolean allowRedstone = true;
+    @Setter private boolean sentWarn = false;
+
+    private final CityBuildPlugin plugin;
+    private final MessageCache cache;
+
+    public void supervice() {
+        RegisteredServiceProvider<Spark> provider = Bukkit.getServicesManager().getRegistration(Spark.class);
+
+        if (provider == null) {
+            Log.warn("Disabling supervision of server tps");
+            return;
+        }
+
+        Spark spark = provider.getProvider();
+
+        threadPool.scheduleAtFixedRate(() -> {
+            DoubleStatistic<StatisticWindow.TicksPerSecond> tps = spark.tps();
+            if (tps == null) return;
+
+            double tpsLast10Secs = tps.poll(StatisticWindow.TicksPerSecond.SECONDS_10);
+
+            // Running relaxing tps logic
+
+            if (tpsLast10Secs > LIMIT_WARN && sentWarn) {
+                DiscordWebhook webhook = new DiscordWebhook(System.getProperty("WEBHOOK_URL"));
+                webhook.addEmbed(new EmbedObject().title("TPS-Protection").description("TPS (letzte 10s) liegt wieder bei 15").color(Color.decode("#62FF00")));
+                executeWebhook(webhook);
+
+                sentWarn(false);
+                return;
+            }
+
+            if (tpsLast10Secs > LIMIT_ALLOW_REDSTONE && !allowRedstone) {
+                Log.info("TPS is again over 10. Allowing redstone..");
+                allowRedstone(true);
+                broadcast(3);
+                return;
+            }
+
+            // Running stressed tps logic
+
+            if (inRange(tpsLast10Secs, LIMIT_WARN, LIMIT_ALLOW_REDSTONE) && !sentWarn) {
+                Log.warn("TPS (last 10s) dropped below 15");
+                broadcast(1);
+
+                DiscordWebhook webhook = new DiscordWebhook(System.getProperty("WEBHOOK_URL"));
+                webhook.addEmbed(new EmbedObject().title("TPS-Protection").description("TPS (letzte 10s) ist unter 15 gefallen").color(Color.decode("#007BFF")));
+                executeWebhook(webhook);
+
+                sentWarn(true);
+                return;
+            }
+
+            if (inRange(tpsLast10Secs, LIMIT_ALLOW_REDSTONE, LIMIT_SHUTDOWN) && allowRedstone) {
+                Log.warn("TPS (last 10s) dropped below 10. Disallowing redstone..");
+                allowRedstone(false);
+                broadcast(2);
+
+                DiscordWebhook webhook = new DiscordWebhook(System.getProperty("WEBHOOK_URL"));
+                webhook.addEmbed(new EmbedObject().title("TPS-Protection").description("TPS (letzte 10s) ist unter 10 gefallen. Deaktiviere Redstone").color(Color.ORANGE));
+                executeWebhook(webhook);
+
+                return;
+            }
+
+            if (tpsLast10Secs <= LIMIT_SHUTDOWN) {
+                Log.warn("TPS (last 10s) dropped below 7. Shutting down server..");
+
+                DiscordWebhook webhook = new DiscordWebhook(System.getProperty("WEBHOOK_URL"));
+                webhook.addEmbed(new EmbedObject().title("TPS-Protection").description("TPS (letzte 10s) ist unter 7 gefallen. Stoppe Server").color(Color.RED));
+                executeWebhook(webhook);
+
+                Bukkit.getScheduler().runTaskLater(plugin, () -> Bukkit.getServer().shutdown(), 20L);
+            }
+
+        }, 0L, 10, TimeUnit.SECONDS);
+    }
+
+    private boolean inRange(double lookup, double min, double max) {
+        return (lookup <= min && lookup > max);
+    }
+
+    private void executeWebhook(@NotNull DiscordWebhook webhook) {
+        try {
+            webhook.execute();
+        } catch (IOException exception) {
+            Log.severe("Executing discord webhook failed with an exception: %s", exception.getMessage());
+        }
+    }
+
+    private void broadcast(int alertLevel) {
+        Component restriction = Component.empty();
+        int tps = 20;
+
+        switch (alertLevel) {
+            case 1 -> {
+                tps = 15;
+                restriction = ComponentTranslator.fromCache(cache, "no-restrictions");
+            }
+            case 2 -> {
+                tps = 10;
+                restriction = ComponentTranslator.fromCache(cache, "disallow-redstone");
+            }
+            case 3 -> {
+                tps = 10;
+                restriction = ComponentTranslator.fromCache(cache, "allow-redstone");
+            }
+        }
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            player.sendMessage(ComponentTranslator.fromCache(cache, "single-line"));
+            player.sendMessage(ComponentTranslator.withReplacements(cache, "warning", List.of(new Replacement<>("%value%", tps))));
+            player.sendMessage(Component.empty());
+            player.sendMessage(ComponentTranslator.fromCache(cache, "restrictions"));
+            player.sendMessage(restriction);
+            player.sendMessage(ComponentTranslator.fromCache(cache, "single-line"));
+
+            player.playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_GROWL, 0.8F, 1.0F);
+        }
+    }
+}

--- a/src/main/java/net/quantrax/citybuild/utils/TPSProtector.java
+++ b/src/main/java/net/quantrax/citybuild/utils/TPSProtector.java
@@ -27,7 +27,9 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class TPSProtector {
 
-    public static final double LIMIT_SHUTDOWN = 7.1D, LIMIT_ALLOW_REDSTONE = 10.1D, LIMIT_WARN = 15.1D;
+    public static final double LIMIT_SHUTDOWN = 7.1D,
+            LIMIT_ALLOW_REDSTONE = 10.1D,
+            LIMIT_WARN = 15.1D;
 
     private final ScheduledExecutorService threadPool = new ScheduledThreadPoolExecutor(3);
     @Getter @Setter private boolean allowRedstone = true;

--- a/src/main/resources/messages.toml
+++ b/src/main/resources/messages.toml
@@ -28,7 +28,7 @@ allow-redstone = "<grey>- <#AEFF00>Redstone wurde wieder aktiviert"
 no-restrictions = "<grey>- /"
 
 [world]
-nether-teleport = "<grey>Du wurdest in das <red>Nether <grey>teleportiert."
+nether-teleport = "<grey>Du wurdest in den <red>Nether <grey>teleportiert."
 farmworld-teleport = "<grey>Du wurdest in die <red>Farmwelt <grey>teleportiert."
 
 [essentials]

--- a/src/main/resources/messages.toml
+++ b/src/main/resources/messages.toml
@@ -18,6 +18,14 @@
 # ======================================================================================================
 
 no-spawn = "<grey>Es wurde <red>kein Spawn <grey>gefunden."
+single-line = "<grey><st>                                                                                                                          "
+
+[tps]
+warning = "<#FFFB00>Warnung: Die TPS (letzte 10s) liegt bei %value%."
+restrictions = "<grey>In Kraft getretene Maßnahmen:"
+disallow-redstone = "<grey>- <#FF0000>Redstone wurde vorübergehend deaktiviert"
+allow-redstone = "<grey>- <#AEFF00>Redstone wurde wieder aktiviert"
+no-restrictions = "<grey>- /"
 
 [world]
 nether-teleport = "<grey>Du wurdest in das <red>Nether <grey>teleportiert."


### PR DESCRIPTION
# Zusammenfassung
Diese PR fügt eine TPS-Protection hinzu, welche über eine Discord-Webhook Benachrichtigungen sendet und in Minecraft ggf. die Funktion von Redstone unterbindet.
___

## Minecraft
- Benachrichtigungen bei einer TPS von 15 und 10; bei 7 wird der Server gestoppt
- De- bzw. Aktivierung von Redstone ab einer Server TPS von 10

<br>

## Developer
- DiscordWebhook

<br>

### Neu hinzugefügte Repositories
- https://oss.sonatype.org/content/repositories/snapshots
  
<br>

### Neu hinzugefügte Abhängigkeiten
- me.lucko:spark-api:0.1-SNAPSHOT
___

## Anmerkungen
Die URL für die DiscordWebhook ist in der `credentials.env` Datei eingetragen und muss daher von jedem Entwickler selbst in die eigene Datei hinzugefügt werden. Der entsprechende Eintrag vom Typ String lautet `WEBHOOK_URL`.  <br>
Die Webhook löst bei einer sinkenden TPS von 15, 10 und 7 aus, bei steigender TPS bei 10 und 15.

___
## Issue-Tracking
Bitte melde alle Fehler oder andere Vorschläge [hier](https://quantraxnet.youtrack.cloud/issues/CB).
___

