### PR TITLE
Feature/clear lag

### DIFF
--- a/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
+++ b/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
@@ -14,6 +14,7 @@ import net.quantrax.citybuild.backend.tracking.PlayerTrackingListener;
 import net.quantrax.citybuild.commands.*;
 import net.quantrax.citybuild.listener.CustomInventoryListener;
 import net.quantrax.citybuild.listener.TPSProtectionListener;
+import net.quantrax.citybuild.utils.ClearLag;
 import net.quantrax.citybuild.utils.TPSProtector;
 import net.quantrax.citybuild.utils.WorldLoader;
 import org.bukkit.Bukkit;
@@ -55,6 +56,8 @@ public class CityBuildPlugin extends JavaPlugin {
 
         tpsProtector = new TPSProtector(this, messageCache);
         tpsProtector.supervice();
+
+        new ClearLag(this, messageCache, toml).execute();
 
         registerListener();
         registerCommands();

--- a/src/main/java/net/quantrax/citybuild/utils/ClearLag.java
+++ b/src/main/java/net/quantrax/citybuild/utils/ClearLag.java
@@ -1,0 +1,71 @@
+package net.quantrax.citybuild.utils;
+
+import com.moandjiezana.toml.Toml;
+import net.kyori.adventure.text.Component;
+import net.quantrax.citybuild.CityBuildPlugin;
+import net.quantrax.citybuild.backend.cache.MessageCache;
+import net.quantrax.citybuild.utils.Messenger.Replacement;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ClearLag {
+
+    private final ScheduledExecutorService threadPool = new ScheduledThreadPoolExecutor(3);
+    private final CityBuildPlugin plugin;
+    private final MessageCache cache;
+    private final long period;
+
+    private int seconds;
+
+    public ClearLag(@NotNull CityBuildPlugin plugin, @NotNull MessageCache cache, @NotNull Toml toml) {
+        this.plugin = plugin;
+        this.cache = cache;
+
+        this.period = toml.getLong("clearlag-period");
+        this.seconds = Math.toIntExact(TimeUnit.MINUTES.toSeconds(period));
+    }
+
+    public void execute() {
+        threadPool.scheduleAtFixedRate(() -> {
+
+            switch (seconds) {
+                case 60, 30, 20, 10, 5, 4, 3, 2 -> broadcast("countdown", true);
+                case 1 -> broadcast("countdown-last-second", false);
+                case 0 -> {
+                    runClearLag();
+                    broadcast("executed", false);
+                }
+            }
+
+            seconds--;
+
+        }, 0L, 1, TimeUnit.SECONDS);
+    }
+
+    private void broadcast(@NotNull String key, boolean hasReplacement) {
+        Component component;
+
+        if (hasReplacement) {
+            component = ComponentTranslator.withReplacements(cache, key, List.of(new Replacement<>("%value%", seconds)));
+
+        } else {
+            component = ComponentTranslator.fromCache(cache, key);
+        }
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            player.sendMessage(component);
+        }
+    }
+
+    private void runClearLag() {
+        seconds = Math.toIntExact(TimeUnit.MINUTES.toSeconds(period)) + 1;
+        Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getWorlds().forEach(world -> world.getEntitiesByClass(Item.class).forEach(Item::remove)));
+    }
+}

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -15,3 +15,4 @@
 farmworld-name = "farmwelt"
 farmworld-spawn-name = "farmwelt-spawn"
 nether-spawn-name = "nether-spawn"
+clearlag-period = 10 # timeunit is minutes

--- a/src/main/resources/messages.toml
+++ b/src/main/resources/messages.toml
@@ -20,6 +20,11 @@
 no-spawn = "<grey>Es wurde <red>kein Spawn <grey>gefunden."
 single-line = "<grey><st>                                                                                                                          "
 
+[clearlag]
+countdown = "<red>Alle auf dem Boden liegenden Items werden in <dark_aqua>%value% <red>Sekunden gelöscht."
+countdown-last-second = "<red>Alle auf dem Boden liegenden Items werden in <dark_aqua>einer <red>Sekunde gelöscht."
+executed = "<red>Alle auf dem Boden liegenden Items wurden gelöscht."
+
 [tps]
 warning = "<#FFFB00>Warnung: Die TPS (letzte 10s) liegt bei %value%."
 restrictions = "<grey>In Kraft getretene Maßnahmen:"


### PR DESCRIPTION
# Zusammenfassung
Diese PR fügt ein Clearlag System hinzu, welches alle x Minuten (in der Config einstellbar) alle auf dem Boden liegenden Items in allen geladenen Welten löscht.
___

## Minecraft
- Clearlag

<br>

## Developer
Keine Neuerungen

<br>

### Neu hinzugefügte Repositories
Keine Neuerungen
  
<br>

### Neu hinzugefügte Abhängigkeiten
Keine Neuerungen
___

## Anmerkungen
Keine Anmerkungen
___
## Issue-Tracking
Bitte melde alle Fehler oder andere Vorschläge [hier](https://quantraxnet.youtrack.cloud/issues/CB).
___

