### PR TITLE
Feature/Chairs

### DIFF
--- a/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
+++ b/src/main/java/net/quantrax/citybuild/CityBuildPlugin.java
@@ -12,6 +12,7 @@ import net.quantrax.citybuild.backend.dao.impl.repository.MessageRepository;
 import net.quantrax.citybuild.backend.dao.impl.repository.PlayerRepository;
 import net.quantrax.citybuild.backend.tracking.PlayerTrackingListener;
 import net.quantrax.citybuild.commands.*;
+import net.quantrax.citybuild.listener.ChairListener;
 import net.quantrax.citybuild.listener.CustomInventoryListener;
 import net.quantrax.citybuild.listener.TPSProtectionListener;
 import net.quantrax.citybuild.utils.ClearLag;
@@ -68,6 +69,7 @@ public class CityBuildPlugin extends JavaPlugin {
         pluginManager.registerEvents(new PlayerTrackingListener(playerCache, playerRepository), this);
         pluginManager.registerEvents(new CustomInventoryListener(), this);
         pluginManager.registerEvents(new TPSProtectionListener(tpsProtector), this);
+        pluginManager.registerEvents(new ChairListener(this), this);
     }
 
     private void registerCommands() {

--- a/src/main/java/net/quantrax/citybuild/listener/ChairListener.java
+++ b/src/main/java/net/quantrax/citybuild/listener/ChairListener.java
@@ -1,0 +1,118 @@
+package net.quantrax.citybuild.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.quantrax.citybuild.CityBuildPlugin;
+import net.quantrax.citybuild.utils.Chair;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.type.Stairs;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RequiredArgsConstructor
+public class ChairListener implements Listener {
+
+    private final Set<Material> stairMaterials = createMaterialSet();
+    private final Collection<Location> occupiedLocations = new ArrayList<>();
+    private final Collection<Player> sittingPlayers = new ArrayList<>();
+    private final Map<Player, ArmorStand> chairs = new ConcurrentHashMap<>();
+    private final Map<Player, Long> lastInteract = new ConcurrentHashMap<>();
+    private final Map<UUID, Location> lastLocation = new HashMap<>();
+
+    private final CityBuildPlugin plugin;
+
+    @EventHandler
+    public void onInteract(@NotNull PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getClickedBlock();
+
+        if (lastInteract.getOrDefault(player, 0L) > System.currentTimeMillis()) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getItem() != null) return;
+        if (block == null) return;
+        if (!stairMaterials.contains(block.getType())) return;
+        if (!(block.getBlockData() instanceof Stairs stairs)) return;
+        if (stairs.getShape() != Stairs.Shape.STRAIGHT) return;
+        if (stairs.getHalf() != Bisected.Half.BOTTOM) return;
+        if (occupiedLocations.contains(block.getLocation())) return;
+        if (sittingPlayers.contains(player)) return;
+
+        lastLocation.put(player.getUniqueId(), player.getLocation());
+
+        new Chair(plugin, block).use(player, chair -> {
+            lastInteract.put(player, System.currentTimeMillis() + 3_000L);
+            chairs.put(player, chair.armorStand());
+            occupiedLocations.add(block.getLocation());
+            sittingPlayers.add(player);
+
+        }, onStandUp -> {
+            sittingPlayers.remove(player);
+            occupiedLocations.remove(block.getLocation());
+            chairs.get(player).remove();
+            chairs.remove(player);
+        });
+    }
+
+    @EventHandler
+    public void onQuit(@NotNull PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+
+        if (!sittingPlayers.contains(player)) return;
+        chairs.get(player).remove();
+    }
+
+    @EventHandler
+    public void onJoin(@NotNull PlayerJoinEvent event) {
+        teleport(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onToggleSneak(@NotNull PlayerToggleSneakEvent event) {
+        Player player = event.getPlayer();
+        if (!sittingPlayers.contains(player)) return;
+
+        teleport(player);
+    }
+
+    @EventHandler
+    public void onBlockBreak(@NotNull BlockBreakEvent event) {
+        event.setCancelled(sittingPlayers.contains(event.getPlayer()));
+    }
+
+    private void teleport(@NotNull Player player) {
+        UUID uuid = player.getUniqueId();
+        if (!lastLocation.containsKey(uuid)) return;
+
+        player.teleport(lastLocation.get(uuid));
+        lastLocation.remove(uuid);
+    }
+
+    @Contract(pure = true)
+    private @NotNull Set<Material> createMaterialSet() {
+        Set<Material> set = new HashSet<>();
+
+        for (Material material : Material.values()) {
+            if (!material.name().contains("STAIR")) continue;
+            if (material.name().contains("LEGACY")) continue;
+
+            set.add(material);
+        }
+
+        return set;
+    }
+}

--- a/src/main/java/net/quantrax/citybuild/utils/Chair.java
+++ b/src/main/java/net/quantrax/citybuild/utils/Chair.java
@@ -1,0 +1,68 @@
+package net.quantrax.citybuild.utils;
+
+import lombok.Getter;
+import net.quantrax.citybuild.CityBuildPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.block.Block;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class Chair {
+
+    private final BukkitScheduler scheduler = Bukkit.getScheduler();
+
+    private final CityBuildPlugin plugin;
+    @Getter private final ArmorStand armorStand;
+
+    public Chair(@NotNull CityBuildPlugin plugin, @NotNull Block block) {
+        this.plugin = plugin;
+        this.armorStand = block.getLocation().getWorld().spawn(block.getLocation().add(0.5D, -1.5D, 0.5D), ArmorStand.class, armorStand -> {
+            armorStand.setInvulnerable(true);
+            armorStand.setSilent(true);
+            armorStand.setVisible(false);
+            armorStand.setGravity(false);
+            armorStand.setCanMove(false);
+            armorStand.setCanTick(false);
+            armorStand.setCollidable(false);
+            armorStand.addEquipmentLock(EquipmentSlot.HEAD, ArmorStand.LockType.ADDING_OR_CHANGING);
+            armorStand.addEquipmentLock(EquipmentSlot.CHEST, ArmorStand.LockType.ADDING_OR_CHANGING);
+            armorStand.addEquipmentLock(EquipmentSlot.LEGS, ArmorStand.LockType.ADDING_OR_CHANGING);
+            armorStand.addEquipmentLock(EquipmentSlot.FEET, ArmorStand.LockType.ADDING_OR_CHANGING);
+            armorStand.addEquipmentLock(EquipmentSlot.HAND, ArmorStand.LockType.ADDING_OR_CHANGING);
+            armorStand.addEquipmentLock(EquipmentSlot.OFF_HAND, ArmorStand.LockType.ADDING_OR_CHANGING);
+        });
+
+        applyGenericZeroHealth();
+    }
+
+    public void use(@NotNull Player player, @NotNull Consumer<Chair> onSitDown, @NotNull Consumer<Void> onStandUp) {
+        armorStand.addPassenger(player);
+        onSitDown.accept(this);
+
+        AtomicInteger taskId = new AtomicInteger();
+        taskId.set(scheduler.scheduleSyncRepeatingTask(plugin, () -> {
+            if (!armorStand.getPassengers().isEmpty()) return;
+
+            armorStand.remove();
+            scheduler.cancelTask(taskId.get());
+            onStandUp.accept(null);
+
+        }, 0L, 20L));
+    }
+
+    private void applyGenericZeroHealth() {
+        AttributeInstance maxHealthAttribute = armorStand.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        if (maxHealthAttribute == null) return;
+
+        maxHealthAttribute.setBaseValue(0D);
+        armorStand.setHealth(0D);
+    }
+}


### PR DESCRIPTION
# Zusammenfassung
Diese PR fügt Stühle in Minecraft hinzu. Diese sind alle ganzen Stufen (nicht Slabs). Um einen Stuhl nutzen zu können, muss ein Spieler diesen Rechtsklicken (alle 3s möglich) und darf dabei keinen Block in der Hand halten. Jeder Stuhl kann nur von einer Person gleichzeitig genutzt werden.
Verlässt man den Stuhl, wird man an die letzte Position vor der Benutzung zurückgesetzt (gilt auch, wenn das Verlassen durch einen Rejoin auf den Server getriggert wird). 
___

## Minecraft
- Stühle

<br>

## Developer
Keine Änderungen

<br>

### Neu hinzugefügte Repositories
Keine Änderungen
  
<br>

### Neu hinzugefügte Abhängigkeiten
Keine Änderungen
___

## Anmerkungen
Keine Anmerkungen

___
## Issue-Tracking
Bitte melde alle Fehler oder andere Vorschläge [hier](https://quantraxnet.youtrack.cloud/issues/CB).
___

